### PR TITLE
update for RN47+

### DIFF
--- a/android/src/main/java/com/inkitt/aptentive/RNApptentivePackage.java
+++ b/android/src/main/java/com/inkitt/aptentive/RNApptentivePackage.java
@@ -24,7 +24,7 @@ public class RNApptentivePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // RN 47+ update
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModules is no longer required for React Native 47+.  It can be left in for backwards compatibility but you have to remove the `@Override` to prevent an error


https://github.com/facebook/react-native/releases/tag/v0.47.2